### PR TITLE
Add Homebrew Update workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Trigger Homebrew Update workflow
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
           curl -f -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/dispatches \


### PR DESCRIPTION
This pull request makes a small change to the release workflow configuration. The main update is switching the `run` step to use a multi-line script block, which improves readability and maintainability of the Homebrew update trigger command.