### PR TITLE
feat: Make fallback relaunch testable and ensure it creates a new app…

### DIFF
--- a/MiddleDrag/Managers/AccessibilityWrappers.swift
+++ b/MiddleDrag/Managers/AccessibilityWrappers.swift
@@ -65,11 +65,20 @@ class SystemAppLifecycleController: AppLifecycleControlling {
         }
     }
 
+    // Closure for opening applications, can be overridden for testing
+    internal var workspaceAppOpener:
+        (URL, NSWorkspace.OpenConfiguration, @escaping (NSRunningApplication?, Error?) -> Void) ->
+            Void = { url, config, completion in
+                NSWorkspace.shared.openApplication(
+                    at: url, configuration: config, completionHandler: completion)
+            }
+
     private func fallbackRelaunch() {
         let url = Bundle.main.bundleURL
         let config = NSWorkspace.OpenConfiguration()
+        config.createsNewApplicationInstance = true
 
-        NSWorkspace.shared.openApplication(at: url, configuration: config) { [weak self] _, error in
+        workspaceAppOpener(url, config) { [weak self] _, error in
             if let error = error {
                 Log.error("Failed to restart app: \(error.localizedDescription)", category: .app)
             } else {


### PR DESCRIPTION
This pull request introduces improvements to the app relaunch logic and enhances testability for the `SystemAppLifecycleController` class. The main changes include making the application opener injectable for testing, ensuring fallback relaunches always create a new app instance, and adding new unit tests to cover this behavior.

**Testability improvements:**

* Added an injectable `workspaceAppOpener` closure to `SystemAppLifecycleController` to allow overriding the application opening logic, making it easier to test app relaunch behavior.

**Relaunch logic improvements:**

* Modified fallback relaunch to always set `createsNewApplicationInstance = true` in the `NSWorkspace.OpenConfiguration`, ensuring a new app instance is created when relaunching.

**Testing enhancements:**

* Added `MockFailingProcessRunner` to simulate process launch failures, enabling tests to trigger fallback relaunch logic.
* Added a new test `testFallbackRelaunchConfiguresNewInstance` to verify that fallback relaunches correctly configure a new application instance and use the injectable opener.