### PR TITLE
Bug/62 windows are a bit sticky

### DIFF
--- a/MiddleDrag/Managers/MultitouchManager.swift
+++ b/MiddleDrag/Managers/MultitouchManager.swift
@@ -444,8 +444,11 @@ class MultitouchManager {
             return Unmanaged.passUnretained(event)
         }
 
-        // During 3-finger gesture: convert left clicks to middle clicks (force click support)
-        if gestureActive && isLeftButton && !isOurEvent {
+        // Force click support: convert left clicks to middle clicks when 3+ fingers are on trackpad
+        // This works based on raw finger count, not gesture activation state, so force clicks
+        // work even when gestures are cancelled (e.g., modifier key not held)
+        let hasThreeOrMoreFingers = currentFingerCount >= 3
+        if hasThreeOrMoreFingers && isLeftButton && !isOurEvent {
             // Check event type - we want to handle both down and up
             if type == .leftMouseDown || type == .leftMouseUp {
                 // Perform middle click instead


### PR DESCRIPTION
This pull request improves the accuracy and reliability of gesture event suppression in the `MultitouchManager` by introducing a new flag to track whether the last gesture was truly active, and by refining the logic for modifier key requirements and gesture detection. These changes help prevent unintended suppression of mouse events after cancelled or invalid gestures, and ensure modifier key requirements are respected for gesture activation.

**Gesture event suppression improvements:**

* Added a new `lastGestureWasActive` flag to track whether the last gesture that ended was actually active (not cancelled), and updated its value in all relevant gesture delegate callbacks (`MiddleDrag/Managers/MultitouchManager.swift`). [[1]](diffhunk://#diff-e3534330904837e4519e4903bf2185e32d7a1c177c87f0915412b419b721639aR37-R38) [[2]](diffhunk://#diff-e3534330904837e4519e4903bf2185e32d7a1c177c87f0915412b419b721639aR530) [[3]](diffhunk://#diff-e3534330904837e4519e4903bf2185e32d7a1c177c87f0915412b419b721639aR560) [[4]](diffhunk://#diff-e3534330904837e4519e4903bf2185e32d7a1c177c87f0915412b419b721639aR623) [[5]](diffhunk://#diff-e3534330904837e4519e4903bf2185e32d7a1c177c87f0915412b419b721639aR635) [[6]](diffhunk://#diff-e3534330904837e4519e4903bf2185e32d7a1c177c87f0915412b419b721639aR645)
* Updated the suppression logic so that left/right mouse events are only suppressed after gesture end if the last gesture was truly active, preventing suppression after cancelled gestures (`MiddleDrag/Managers/MultitouchManager.swift`).

**Gesture activation and modifier key handling:**

* Refined gesture activation checks to ensure gestures are only considered active when the required modifier key is held (if configured), using explicit flags instead of relying on finger count or gesture recognizer state (`MiddleDrag/Managers/MultitouchManager.swift`).

**State reset and cleanup:**

* Ensured that both `lastGestureWasActive` and `gestureEndTime` are reset whenever the manager is stopped or disabled, improving state consistency (`MiddleDrag/Managers/MultitouchManager.swift`). [[1]](diffhunk://#diff-e3534330904837e4519e4903bf2185e32d7a1c177c87f0915412b419b721639aR244-R245) [[2]](diffhunk://#diff-e3534330904837e4519e4903bf2185e32d7a1c177c87f0915412b419b721639aR297-R298)