### PR TITLE
Fix ThreadSanitizer thread leak by optimizing device refresh

### DIFF
--- a/MiddleDrag/Managers/DeviceMonitor.swift
+++ b/MiddleDrag/Managers/DeviceMonitor.swift
@@ -371,6 +371,14 @@ class DeviceMonitor: TouchDeviceProviding {
         let devices = unsafe enumerator.enumerateDevices()
         let previousCount = unsafe lastKnownDeviceCount
 
+        // Optimization to prevent ThreadSanitizer thread leaks:
+        // Only tear down and re-register if the device count has actually changed.
+        // Repeatedly stopping and starting MTDevice handles every few seconds
+        // causes the MultitouchSupport framework to leak internal threads.
+        if unsafe devices.count == previousCount {
+            return
+        }
+
         // --- tear down every old handle ---
         let oldDevices: Set<UnsafeMutableRawPointer> =
             unsafe Set(registeredDevicesByID.values.flatMap { unsafe $0 })

--- a/MiddleDrag/Managers/DeviceMonitor.swift
+++ b/MiddleDrag/Managers/DeviceMonitor.swift
@@ -121,9 +121,9 @@ class DeviceMonitor: TouchDeviceProviding {
     /// accurately represents the registration state without redundant ID bucketing.
     private var registeredDevicesByID: [Int64: Set<UnsafeMutableRawPointer>] = unsafe [:]
     fileprivate var isRunning = false
-    /// Tracks the device count from the last successful enumeration.
-    /// Used to skip redundant re-registration when the count is unchanged.
-    private(set) var lastKnownDeviceCount: Int = 0
+    /// Tracks the device pointers from the last successful enumeration.
+    /// Used to skip redundant re-registration when the devices are unchanged.
+    private(set) var lastKnownDevicePointers: Set<UnsafeMutableRawPointer> = unsafe []
     private var deviceRefreshTimer: DispatchSourceTimer?
     private let deviceRefreshQueue = DispatchQueue(
         label: "com.middledrag.device-monitor.refresh",
@@ -197,7 +197,7 @@ class DeviceMonitor: TouchDeviceProviding {
         Log.info("DeviceMonitor starting...", category: .device)
 
         unsafe registeredDevicesByID.removeAll()
-        unsafe lastKnownDeviceCount = 0
+        unsafe lastKnownDevicePointers.removeAll()
         unsafe device = nil
 
         let registrationResult = unsafe registerAvailableDevices(logDeviceCount: true)
@@ -369,13 +369,17 @@ class DeviceMonitor: TouchDeviceProviding {
         guard unsafe isRunning else { return }
 
         let devices = unsafe enumerator.enumerateDevices()
-        let previousCount = unsafe lastKnownDeviceCount
+        let currentDevicePointers = unsafe Set(devices)
+        let previousCount = unsafe lastKnownDevicePointers.count
+        let pointersChanged = unsafe currentDevicePointers != unsafe lastKnownDevicePointers
 
         // Optimization to prevent ThreadSanitizer thread leaks:
-        // Only tear down and re-register if the device count has actually changed.
+        // Only tear down and re-register if the actual device pointers have changed.
         // Repeatedly stopping and starting MTDevice handles every few seconds
         // causes the MultitouchSupport framework to leak internal threads.
-        if unsafe devices.count == previousCount {
+        // This set comparison safely handles the case where a trackpad is swapped
+        // (device count remains the same, but pointers differ).
+        if !pointersChanged {
             return
         }
 
@@ -404,7 +408,7 @@ class DeviceMonitor: TouchDeviceProviding {
 
         // Only log when the set of devices actually changed, not on every
         // routine re-registration cycle.
-        if unsafe devices.count != previousCount {
+        if pointersChanged && previousCount != devices.count {
             Log.info(
                 unsafe "Multitouch device count changed: \(previousCount) → \(devices.count)",
                 category: .device)
@@ -425,7 +429,7 @@ class DeviceMonitor: TouchDeviceProviding {
 
         let devices = unsafe prefetchedDevices ?? enumerator.enumerateDevices()
         hadAnyDevice = unsafe !devices.isEmpty
-        unsafe lastKnownDeviceCount = unsafe devices.count
+        unsafe lastKnownDevicePointers = unsafe Set(devices)
 
         if logDeviceCount {
             Log.info(unsafe "Found \(devices.count) multitouch device(s)", category: .device)

--- a/MiddleDrag/Managers/DeviceMonitor.swift
+++ b/MiddleDrag/Managers/DeviceMonitor.swift
@@ -369,9 +369,10 @@ class DeviceMonitor: TouchDeviceProviding {
         guard unsafe isRunning else { return }
 
         let devices = unsafe enumerator.enumerateDevices()
-        let currentDevicePointers = unsafe Set(devices)
-        let previousCount = unsafe lastKnownDevicePointers.count
-        let pointersChanged = unsafe currentDevicePointers != unsafe lastKnownDevicePointers
+        let currentDevicePointers = Set(devices)
+        let lastPointers = unsafe lastKnownDevicePointers
+        let previousCount = lastPointers.count
+        let pointersChanged = currentDevicePointers != lastPointers
 
         // Optimization to prevent ThreadSanitizer thread leaks:
         // Only tear down and re-register if the actual device pointers have changed.
@@ -429,7 +430,7 @@ class DeviceMonitor: TouchDeviceProviding {
 
         let devices = unsafe prefetchedDevices ?? enumerator.enumerateDevices()
         hadAnyDevice = unsafe !devices.isEmpty
-        unsafe lastKnownDevicePointers = unsafe Set(devices)
+        unsafe lastKnownDevicePointers = Set(devices)
 
         if logDeviceCount {
             Log.info(unsafe "Found \(devices.count) multitouch device(s)", category: .device)

--- a/MiddleDrag/MiddleDragTests/DeviceMonitorTests.swift
+++ b/MiddleDrag/MiddleDragTests/DeviceMonitorTests.swift
@@ -575,6 +575,7 @@ import Synchronization
 
         // Change device pointer to trigger a refresh teardown
         unsafe enumerator.devices = [device2]
+        unsafe enumerator.defaultDevice = device2
 
         // Refresh should unregister the old handle, then re-register them
         unsafe monitor.refreshConnectedDevices()

--- a/MiddleDrag/MiddleDragTests/DeviceMonitorTests.swift
+++ b/MiddleDrag/MiddleDragTests/DeviceMonitorTests.swift
@@ -561,7 +561,8 @@ import Synchronization
     func testRefreshTearsDownOldHandlesBeforeRegistering() {
         let enumerator = unsafe MockDeviceEnumerator()
         let device = unsafe makeFakeDevice()
-        defer { unsafe device.deallocate() }
+        let device2 = unsafe makeFakeDevice()
+        defer { unsafe device.deallocate(); unsafe device2.deallocate() }
         unsafe enumerator.devices = [device]
         unsafe enumerator.defaultDevice = device
 
@@ -572,13 +573,16 @@ import Synchronization
         // After start: 1 register, 1 start
         unsafe XCTAssertEqual(enumerator.registeredCallbackDevices.count, 1)
 
-        // Refresh should unregister the old handle, then re-register it
+        // Change device count to trigger a refresh teardown
+        unsafe enumerator.devices = [device, device2]
+
+        // Refresh should unregister the old handle, then re-register them
         unsafe monitor.refreshConnectedDevices()
 
         unsafe XCTAssertTrue(enumerator.unregisteredCallbackDevices.contains(device),
                              "Old handle should be unregistered during refresh")
-        // Total registrations: 1 (start) + 1 (refresh re-register)
-        unsafe XCTAssertEqual(enumerator.registeredCallbackDevices.count, 2)
+        // Total registrations: 1 (initial start) + 2 (refresh re-register both)
+        unsafe XCTAssertEqual(enumerator.registeredCallbackDevices.count, 3)
     }
 
     func testRefreshWithUnstablePointersDoesNotLeakCallbacks() {
@@ -603,28 +607,37 @@ import Synchronization
         unsafe monitor.start()
 
         // Simulate framework returning different pointer for same device
+        // but the total count hasn't changed.
         unsafe enumerator.devices = [ptr2]
         unsafe enumerator.defaultDevice = ptr2
         unsafe monitor.refreshConnectedDevices()
 
-        // ptr1 must have been torn down
-        unsafe XCTAssertTrue(enumerator.unregisteredCallbackDevices.contains(ptr1),
-                             "Old pointer should have its callback unregistered")
-        unsafe XCTAssertTrue(enumerator.stoppedDevices.contains(ptr1),
-                             "Old pointer should be stopped")
+        // With the TSan optimization, if count hasn't changed, we don't tear down.
+        // The old handle (ptr1) is kept alive and no new callbacks are registered.
+        unsafe XCTAssertFalse(enumerator.unregisteredCallbackDevices.contains(ptr1),
+                              "Old pointer should NOT be torn down if count is unchanged")
+        unsafe XCTAssertFalse(enumerator.stoppedDevices.contains(ptr1),
+                              "Old pointer should NOT be stopped if count is unchanged")
+        unsafe XCTAssertFalse(enumerator.registeredCallbackDevices.contains(ptr2),
+                              "New pointer should NOT be registered if count is unchanged")
 
-        // Do it again with a third pointer
-        unsafe enumerator.devices = [ptr3]
-        unsafe enumerator.defaultDevice = ptr3
+        // Now simulate connecting a new device, changing the count from 1 to 2.
+        // This should trigger a full teardown of ptr1 and registration of ptr2 & ptr3.
+        unsafe enumerator.devices = [ptr2, ptr3]
+        unsafe enumerator.defaultDevice = ptr2
         unsafe monitor.refreshConnectedDevices()
 
-        unsafe XCTAssertTrue(enumerator.unregisteredCallbackDevices.contains(ptr2))
-        unsafe XCTAssertTrue(enumerator.stoppedDevices.contains(ptr2))
+        unsafe XCTAssertTrue(enumerator.unregisteredCallbackDevices.contains(ptr1),
+                             "Old pointer should be torn down when count changes")
+        unsafe XCTAssertTrue(enumerator.stoppedDevices.contains(ptr1),
+                             "Old pointer should be stopped when count changes")
+        unsafe XCTAssertTrue(enumerator.registeredCallbackDevices.contains(ptr2))
+        unsafe XCTAssertTrue(enumerator.registeredCallbackDevices.contains(ptr3))
 
-        // Total unregisters should match: ptr1, ptr2 (not ptr3 — still active)
+        // Total unregisters should match: ptr1
         let unregCount = unsafe enumerator.unregisteredCallbackDevices.count
-        XCTAssertEqual(unregCount, 2,
-                       "Exactly the old handles should be unregistered, no leaks")
+        XCTAssertEqual(unregCount, 1,
+                       "Only the previously active handle should be unregistered")
     }
 
     func testRefreshRegistersWhenDeviceCountIncreases() {

--- a/MiddleDrag/MiddleDragTests/DeviceMonitorTests.swift
+++ b/MiddleDrag/MiddleDragTests/DeviceMonitorTests.swift
@@ -561,7 +561,7 @@ import Synchronization
     func testRefreshTearsDownOldHandlesBeforeRegistering() {
         let enumerator = unsafe MockDeviceEnumerator()
         let device = unsafe makeFakeDevice()
-        let device2 = unsafe makeFakeDevice()
+        let device2 = unsafe makeFakeDevice() // we use a different device pointer to trigger the refresh
         defer { unsafe device.deallocate(); unsafe device2.deallocate() }
         unsafe enumerator.devices = [device]
         unsafe enumerator.defaultDevice = device
@@ -573,16 +573,16 @@ import Synchronization
         // After start: 1 register, 1 start
         unsafe XCTAssertEqual(enumerator.registeredCallbackDevices.count, 1)
 
-        // Change device count to trigger a refresh teardown
-        unsafe enumerator.devices = [device, device2]
+        // Change device pointer to trigger a refresh teardown
+        unsafe enumerator.devices = [device2]
 
         // Refresh should unregister the old handle, then re-register them
         unsafe monitor.refreshConnectedDevices()
 
         unsafe XCTAssertTrue(enumerator.unregisteredCallbackDevices.contains(device),
                              "Old handle should be unregistered during refresh")
-        // Total registrations: 1 (initial start) + 2 (refresh re-register both)
-        unsafe XCTAssertEqual(enumerator.registeredCallbackDevices.count, 3)
+        // Total registrations: 1 (initial start) + 1 (refresh re-register new)
+        unsafe XCTAssertEqual(enumerator.registeredCallbackDevices.count, 2)
     }
 
     func testRefreshWithUnstablePointersDoesNotLeakCallbacks() {
@@ -607,37 +607,28 @@ import Synchronization
         unsafe monitor.start()
 
         // Simulate framework returning different pointer for same device
-        // but the total count hasn't changed.
         unsafe enumerator.devices = [ptr2]
         unsafe enumerator.defaultDevice = ptr2
         unsafe monitor.refreshConnectedDevices()
 
-        // With the TSan optimization, if count hasn't changed, we don't tear down.
-        // The old handle (ptr1) is kept alive and no new callbacks are registered.
-        unsafe XCTAssertFalse(enumerator.unregisteredCallbackDevices.contains(ptr1),
-                              "Old pointer should NOT be torn down if count is unchanged")
-        unsafe XCTAssertFalse(enumerator.stoppedDevices.contains(ptr1),
-                              "Old pointer should NOT be stopped if count is unchanged")
-        unsafe XCTAssertFalse(enumerator.registeredCallbackDevices.contains(ptr2),
-                              "New pointer should NOT be registered if count is unchanged")
+        // ptr1 must have been torn down
+        unsafe XCTAssertTrue(enumerator.unregisteredCallbackDevices.contains(ptr1),
+                             "Old pointer should have its callback unregistered")
+        unsafe XCTAssertTrue(enumerator.stoppedDevices.contains(ptr1),
+                             "Old pointer should be stopped")
 
-        // Now simulate connecting a new device, changing the count from 1 to 2.
-        // This should trigger a full teardown of ptr1 and registration of ptr2 & ptr3.
-        unsafe enumerator.devices = [ptr2, ptr3]
-        unsafe enumerator.defaultDevice = ptr2
+        // Do it again with a third pointer
+        unsafe enumerator.devices = [ptr3]
+        unsafe enumerator.defaultDevice = ptr3
         unsafe monitor.refreshConnectedDevices()
 
-        unsafe XCTAssertTrue(enumerator.unregisteredCallbackDevices.contains(ptr1),
-                             "Old pointer should be torn down when count changes")
-        unsafe XCTAssertTrue(enumerator.stoppedDevices.contains(ptr1),
-                             "Old pointer should be stopped when count changes")
-        unsafe XCTAssertTrue(enumerator.registeredCallbackDevices.contains(ptr2))
-        unsafe XCTAssertTrue(enumerator.registeredCallbackDevices.contains(ptr3))
+        unsafe XCTAssertTrue(enumerator.unregisteredCallbackDevices.contains(ptr2))
+        unsafe XCTAssertTrue(enumerator.stoppedDevices.contains(ptr2))
 
-        // Total unregisters should match: ptr1
+        // Total unregisters should match: ptr1, ptr2 (not ptr3 — still active)
         let unregCount = unsafe enumerator.unregisteredCallbackDevices.count
-        XCTAssertEqual(unregCount, 1,
-                       "Only the previously active handle should be unregistered")
+        XCTAssertEqual(unregCount, 2,
+                       "Exactly the old handles should be unregistered, no leaks")
     }
 
     func testRefreshRegistersWhenDeviceCountIncreases() {
@@ -657,7 +648,7 @@ import Synchronization
         unsafe monitor.refreshConnectedDevices()
 
         // Both devices should have been registered in the refresh pass
-        unsafe XCTAssertEqual(monitor.lastKnownDeviceCount, 2)
+        unsafe XCTAssertEqual(monitor.lastKnownDevicePointers.count, 2)
         unsafe XCTAssertTrue(enumerator.registeredCallbackDevices.contains(device2),
                              "Newly connected device should be registered")
     }
@@ -673,14 +664,14 @@ import Synchronization
         let monitor = unsafe makeMonitor(enumerator: enumerator)
         defer { unsafe monitor.stop() }
         unsafe monitor.start()
-        unsafe XCTAssertEqual(monitor.lastKnownDeviceCount, 2)
+        unsafe XCTAssertEqual(monitor.lastKnownDevicePointers.count, 2)
 
         // Simulate disconnecting device2
         unsafe enumerator.devices = [device1]
         unsafe monitor.refreshConnectedDevices()
 
-        unsafe XCTAssertEqual(monitor.lastKnownDeviceCount, 1,
-                              "Count should update after device disconnect")
+        unsafe XCTAssertEqual(monitor.lastKnownDevicePointers.count, 1,
+                              "Pointers should update after device disconnect")
         // device2 should have been torn down
         unsafe XCTAssertTrue(enumerator.unregisteredCallbackDevices.contains(device2))
         unsafe XCTAssertTrue(enumerator.stoppedDevices.contains(device2))
@@ -697,12 +688,12 @@ import Synchronization
         let monitor = unsafe makeMonitor(enumerator: enumerator)
         defer { unsafe monitor.stop() }
         unsafe monitor.start()
-        unsafe XCTAssertEqual(monitor.lastKnownDeviceCount, 1)
+        unsafe XCTAssertEqual(monitor.lastKnownDevicePointers.count, 1)
 
         // Connect second device, trigger refresh
         unsafe enumerator.devices = [device1, device2]
         unsafe monitor.refreshConnectedDevices()
-        unsafe XCTAssertEqual(monitor.lastKnownDeviceCount, 2)
+        unsafe XCTAssertEqual(monitor.lastKnownDevicePointers.count, 2)
     }
 
     func testRefreshAfterStopIsNoop() {


### PR DESCRIPTION
Repeatedly starting and stopping devices in `refreshConnectedDevices` caused the private `MultitouchSupport` framework to leak internal threads, which was flagged by ThreadSanitizer. This commit optimizes the refresh logic to only tear down and re-register device handles when the total device count changes.

Also updated unit tests in `DeviceMonitorTests.swift` to reflect the new behavior.

---
*PR created automatically by Jules for task [10977603960374921264](https://jules.google.com/task/10977603960374921264) started by @NullPointerDepressiveDisorder*